### PR TITLE
feat: add mnemonic storage functionality

### DIFF
--- a/src/context/walletContext.tsx
+++ b/src/context/walletContext.tsx
@@ -10,6 +10,10 @@ import { createCtx } from '.';
 import { createWeb3Wallet } from '../utils/web3';
 import { createWallet } from '../utils/wallet';
 
+interface InitProps {
+  mnemonic?: string;
+}
+
 // State variables only
 interface WalletContextState {
   wallet?: Wallet;
@@ -21,8 +25,8 @@ interface WalletContextState {
 // because it holds any other option or fx
 // that handle the state in some way
 interface WalletContext extends WalletContextState {
-  initContext: (mnemonic?: string) => Promise<void>;
-  initWallet: (mnemonic?: string) => void;
+  initContext: (v?: InitProps) => Promise<void>;
+  initWallet: (v?: InitProps) => void;
 }
 
 const INITIAL_STATE: WalletContextState = {
@@ -40,13 +44,13 @@ const [useContext, WalletContextProvider] =
 export const WalletProvider = ({ children }: PropsWithChildren) => {
   const [state, setState] = useState<WalletContextState>(INITIAL_STATE);
 
-  const initContext = async (mnemonic?: string) =>
+  const initContext = async (props?: InitProps) =>
     await createWeb3Wallet(state.web3Core)
       .then(web3Wallet => setState(prevState => ({ ...prevState, web3Wallet })))
-      .then(() => initWallet(mnemonic));
+      .then(() => initWallet({ mnemonic: props?.mnemonic }));
 
-  const initWallet = (mnemonic?: string) => {
-    const wallet = createWallet(mnemonic);
+  const initWallet = (props?: InitProps) => {
+    const wallet = createWallet(props?.mnemonic);
     setState(prevState => ({ ...prevState, wallet }));
   };
 

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -1,9 +1,11 @@
 import React, { PropsWithChildren } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { StyleSheet, TouchableOpacity, View } from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 
 import { Content, ThemedText } from '../components/';
-import { RootStackScreenProps } from '../navigation';
 import { useWalletContext } from '../context/walletContext';
+import { RootStackScreenProps } from '../navigation';
+import { RootNavigator } from '../navigation/utils';
 
 export const HomeScreen = ({}: PropsWithChildren<
   RootStackScreenProps<'Main'>
@@ -11,6 +13,12 @@ export const HomeScreen = ({}: PropsWithChildren<
   const { wallet } = useWalletContext();
   const address = wallet?.address ?? '';
   const mnemonic = wallet?.mnemonic.phrase ?? '';
+
+  const handleLogOut = async () => {
+    await AsyncStorage.removeItem('mnemonic').then(() =>
+      RootNavigator.navigate('Onboarding'),
+    );
+  };
 
   return (
     <Content containerStyle={styles.container}>
@@ -22,6 +30,12 @@ export const HomeScreen = ({}: PropsWithChildren<
         <ThemedText style={styles.heading}>Wallet info</ThemedText>
         <ThemedText>Address: {address}</ThemedText>
         <ThemedText>Mnemonic phrase: {mnemonic}</ThemedText>
+      </View>
+      <View style={styles.group}>
+        <ThemedText style={styles.heading}>Log Out</ThemedText>
+        <TouchableOpacity onPress={handleLogOut} style={styles.button}>
+          <ThemedText>Press to log out</ThemedText>
+        </TouchableOpacity>
       </View>
     </Content>
   );
@@ -39,5 +53,11 @@ const styles = StyleSheet.create({
   heading: {
     fontSize: 20,
     fontWeight: '700',
+  },
+  button: {
+    borderRadius: 8,
+    padding: 16,
+    alignSelf: 'flex-start',
+    backgroundColor: '#AFAFAF',
   },
 });

--- a/src/screens/OnboardingScreen.tsx
+++ b/src/screens/OnboardingScreen.tsx
@@ -19,7 +19,7 @@ export const OnboardingScreen = ({
     }
 
     setLoadingWallet(true);
-    await initContext()
+    await initContext({ saveInStorage: shouldRememberUser })
       .then(() => setLoadingWallet(false))
       .finally(() => navigation.navigate('Main'));
   };

--- a/src/screens/OnboardingScreen.tsx
+++ b/src/screens/OnboardingScreen.tsx
@@ -1,5 +1,5 @@
 import React, { PropsWithChildren, useState } from 'react';
-import { StyleSheet, TouchableOpacity } from 'react-native';
+import { StyleSheet, TouchableOpacity, View } from 'react-native';
 
 import { useWalletContext } from '../context/walletContext';
 import { RootStackScreenProps } from '../navigation';
@@ -10,6 +10,7 @@ export const OnboardingScreen = ({
 }: PropsWithChildren<RootStackScreenProps<'Onboarding'>>) => {
   const { initContext, wallet, web3Wallet } = useWalletContext();
   const [loadingWallet, setLoadingWallet] = useState(false);
+  const [shouldRememberUser, setShouldRememberUser] = useState(false);
 
   const isInit = !!web3Wallet && !!wallet;
   const handleOnPress = async () => {
@@ -23,6 +24,10 @@ export const OnboardingScreen = ({
       .finally(() => navigation.navigate('Main'));
   };
 
+  const handleRememberMe = () => {
+    setShouldRememberUser(prevState => !prevState);
+  };
+
   const buttonText = isInit
     ? 'Wallet Ready 🚀'
     : loadingWallet
@@ -32,6 +37,12 @@ export const OnboardingScreen = ({
   return (
     <Content containerStyle={styles.container}>
       <ThemedText>Hello World!</ThemedText>
+      <TouchableOpacity onPress={handleRememberMe} style={styles.row}>
+        <View
+          style={[styles.box, shouldRememberUser && styles.blueBackgroundColor]}
+        />
+        <ThemedText>Remember me</ThemedText>
+      </TouchableOpacity>
       <TouchableOpacity onPress={handleOnPress} style={styles.button}>
         <ThemedText style={styles.whiteText}>{buttonText}</ThemedText>
       </TouchableOpacity>
@@ -53,5 +64,20 @@ const styles = StyleSheet.create({
   },
   whiteText: {
     color: 'white',
+  },
+  row: {
+    flexDirection: 'row',
+    gap: 8,
+    alignItems: 'center',
+  },
+  box: {
+    borderRadius: 4,
+    borderWidth: 1,
+    borderColor: 'gray',
+    width: 20,
+    height: 20,
+  },
+  blueBackgroundColor: {
+    backgroundColor: '#0066FF',
   },
 });

--- a/src/screens/OnboardingScreen.tsx
+++ b/src/screens/OnboardingScreen.tsx
@@ -1,5 +1,6 @@
-import React, { PropsWithChildren, useState } from 'react';
+import React, { PropsWithChildren, useEffect, useState } from 'react';
 import { StyleSheet, TouchableOpacity, View } from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 
 import { useWalletContext } from '../context/walletContext';
 import { RootStackScreenProps } from '../navigation';
@@ -11,6 +12,22 @@ export const OnboardingScreen = ({
   const { initContext, wallet, web3Wallet } = useWalletContext();
   const [loadingWallet, setLoadingWallet] = useState(false);
   const [shouldRememberUser, setShouldRememberUser] = useState(false);
+
+  // @TODO: move to loading screen
+  useEffect(() => {
+    (async () => {
+      const storedMnemonic = await AsyncStorage.getItem('mnemonic');
+      if (storedMnemonic) {
+        setLoadingWallet(true);
+        await initContext({
+          saveInStorage: shouldRememberUser,
+          mnemonic: storedMnemonic,
+        })
+          .then(() => setLoadingWallet(false))
+          .finally(() => navigation.navigate('Main'));
+      }
+    })();
+  }, []);
 
   const isInit = !!web3Wallet && !!wallet;
   const handleOnPress = async () => {


### PR DESCRIPTION
## Description

To keep things simple we used `AsyncStorage`. As a side-note, we left a _todo_ comment to address the security issue regarding AsyncStorage but for the time being (and this being a sandbox/demo app) we will keep it as it is.

The idea is that the user does their first log in on the OnboardingScreen and that afterwards it is no longer needed for them to keep going that flow.

If the app is closed or refreshed, the user will be able to enter the app with the previous wallet configuration they had.

Next, we shall use a LoadingScreen instead of the onboarding one to mask the bare bones of the operation.

## Related links

- Closes #11 

## Proof

| _Demo_ |
| :---: |
| <video src='https://github.com/juanmanso/rn-walletconnect/assets/21087992/03caed2d-fa91-45e9-b8de-068735b768fb' width=400> |