### PR TITLE
feat: add loading screen

### DIFF
--- a/src/context/walletContext.tsx
+++ b/src/context/walletContext.tsx
@@ -59,10 +59,14 @@ export const WalletProvider = ({ children }: PropsWithChildren) => {
   };
 
   const initContext = async (props?: InitProps) => {
-    await createWeb3Wallet(state.web3Core).then(web3Wallet =>
-      setState(prevState => ({ ...prevState, web3Wallet })),
-    );
-    await initWallet(props);
+    if (!state.web3Wallet) {
+      await createWeb3Wallet(state.web3Core).then(web3Wallet =>
+        setState(prevState => ({ ...prevState, web3Wallet })),
+      );
+    }
+    if (!state.wallet) {
+      await initWallet(props);
+    }
   };
 
   const initWallet = async (props?: InitProps) => {

--- a/src/navigation/index.tsx
+++ b/src/navigation/index.tsx
@@ -53,7 +53,7 @@ const AppNavigator = () => {
         name="Onboarding"
         component={OnboardingScreen}
         options={{
-          ...TransitionPresets.ModalPresentationIOS,
+          gestureEnabled: false,
           title: 'Onboarding',
         }}
       />

--- a/src/navigation/index.tsx
+++ b/src/navigation/index.tsx
@@ -9,11 +9,13 @@ import {
 
 import { RootNavigator } from './utils';
 import { HomeScreen } from '../screens/HomeScreen';
+import { LoadingScreen } from '../screens/LoadingScreen';
 import { OnboardingScreen } from '../screens/OnboardingScreen';
 
 export type RootStackParamList = {
   Main: undefined;
   Onboarding: undefined;
+  Loading: undefined;
 };
 
 export type RootStackNavigationProps<Route extends keyof RootStackParamList> =
@@ -36,7 +38,7 @@ const AppNavigator = () => {
   return (
     <Stack.Navigator
       // TODO: check if wallet was previously initiated
-      initialRouteName={'Onboarding'}
+      initialRouteName={'Loading'}
       screenOptions={{ headerShown: false }}
     >
       <Stack.Screen
@@ -53,6 +55,14 @@ const AppNavigator = () => {
         options={{
           ...TransitionPresets.ModalPresentationIOS,
           title: 'Onboarding',
+        }}
+      />
+      <Stack.Screen
+        name="Loading"
+        component={LoadingScreen}
+        options={{
+          ...TransitionPresets.ModalPresentationIOS,
+          title: 'Loading',
         }}
       />
     </Stack.Navigator>

--- a/src/screens/LoadingScreen.tsx
+++ b/src/screens/LoadingScreen.tsx
@@ -7,7 +7,7 @@ import { Content, ThemedText } from '../components';
 type LoadingStates = 'fetchingLocalStorage' | 'logged' | 'yetToOnboard';
 
 const statusTextByState: Record<LoadingStates, string> = {
-  fetchingLocalStorage: "Preppin' the app...",
+  fetchingLocalStorage: 'Fetching some data...',
   logged: 'Logging in...',
   yetToOnboard: 'Redirecting to onboarding...',
 };
@@ -15,8 +15,10 @@ const statusTextByState: Record<LoadingStates, string> = {
 export const LoadingScreen = ({}: PropsWithChildren<
   RootStackScreenProps<'Loading'>
 >) => {
-  const [loadingState, _] = useState<LoadingStates>('fetchingLocalStorage');
-  const statusText = statusTextByState[loadingState];
+  const [loadingState, _] = useState<LoadingStates>();
+  const statusText = loadingState
+    ? statusTextByState[loadingState]
+    : "Preppin' the app...";
 
   return (
     <Content containerStyle={styles.container}>

--- a/src/screens/LoadingScreen.tsx
+++ b/src/screens/LoadingScreen.tsx
@@ -1,0 +1,26 @@
+import React, { PropsWithChildren } from 'react';
+import { ActivityIndicator, StyleSheet } from 'react-native';
+
+import { RootStackScreenProps } from '../navigation';
+import { Content, ThemedText } from '../components';
+
+export const LoadingScreen = ({}: PropsWithChildren<
+  RootStackScreenProps<'Loading'>
+>) => {
+  const statusText = "Preppin' the app";
+
+  return (
+    <Content containerStyle={styles.container}>
+      <ActivityIndicator size={'large'} />
+      <ThemedText type="H1">{statusText}</ThemedText>
+    </Content>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    justifyContent: 'center',
+    alignItems: 'center',
+    gap: 32,
+  },
+});

--- a/src/screens/LoadingScreen.tsx
+++ b/src/screens/LoadingScreen.tsx
@@ -1,13 +1,22 @@
-import React, { PropsWithChildren } from 'react';
+import React, { PropsWithChildren, useState } from 'react';
 import { ActivityIndicator, StyleSheet } from 'react-native';
 
 import { RootStackScreenProps } from '../navigation';
 import { Content, ThemedText } from '../components';
 
+type LoadingStates = 'fetchingLocalStorage' | 'logged' | 'yetToOnboard';
+
+const statusTextByState: Record<LoadingStates, string> = {
+  fetchingLocalStorage: "Preppin' the app...",
+  logged: 'Logging in...',
+  yetToOnboard: 'Redirecting to onboarding...',
+};
+
 export const LoadingScreen = ({}: PropsWithChildren<
   RootStackScreenProps<'Loading'>
 >) => {
-  const statusText = "Preppin' the app";
+  const [loadingState, _] = useState<LoadingStates>('fetchingLocalStorage');
+  const statusText = statusTextByState[loadingState];
 
   return (
     <Content containerStyle={styles.container}>

--- a/src/screens/LoadingScreen.tsx
+++ b/src/screens/LoadingScreen.tsx
@@ -1,4 +1,4 @@
-import React, { PropsWithChildren, useState } from 'react';
+import React, { PropsWithChildren, useEffect, useState } from 'react';
 import { ActivityIndicator, StyleSheet } from 'react-native';
 
 import { RootStackScreenProps } from '../navigation';
@@ -15,10 +15,21 @@ const statusTextByState: Record<LoadingStates, string> = {
 export const LoadingScreen = ({}: PropsWithChildren<
   RootStackScreenProps<'Loading'>
 >) => {
-  const [loadingState, _] = useState<LoadingStates>();
+  const [loadingState, setLoadingState] = useState<LoadingStates>();
   const statusText = loadingState
     ? statusTextByState[loadingState]
     : "Preppin' the app...";
+
+  useEffect(() => {
+    const fetchData = async () => {
+      await AsyncStorage.getItem('mnemonic');
+    };
+
+    if (!loadingState) {
+      setLoadingState('fetchingLocalStorage');
+      fetchData();
+    }
+  }, [loadingState]);
 
   return (
     <Content containerStyle={styles.container}>

--- a/src/screens/LoadingScreen.tsx
+++ b/src/screens/LoadingScreen.tsx
@@ -15,9 +15,9 @@ const statusTextByState: Record<LoadingStates, string> = {
   yetToOnboard: 'Redirecting to onboarding...',
 };
 
-export const LoadingScreen = ({}: PropsWithChildren<
-  RootStackScreenProps<'Loading'>
->) => {
+export const LoadingScreen = ({
+  navigation,
+}: PropsWithChildren<RootStackScreenProps<'Loading'>>) => {
   const [loadingState, setLoadingState] = useState<LoadingStates>();
   const { initContext } = useWalletContext();
   const statusText = loadingState
@@ -31,11 +31,14 @@ export const LoadingScreen = ({}: PropsWithChildren<
         const isUserReady = isValidMnemonic(value);
         if (isUserReady) {
           setLoadingState('logged');
-          await initContext();
+          await initContext().then(() => {
+            navigation.navigate('Main');
+          });
           return;
         }
       }
       setLoadingState('yetToOnboard');
+      navigation.navigate('Onboarding');
     };
 
     if (!loadingState) {


### PR DESCRIPTION
## Description

The following PR adds a new screen called `Loading`. It's goal is to be the catch-all screen for the time in between fetching data to define which final screen to show.

## Related links

- Closes #13 

## Proof

| _Demo_ |
| :---: |
| <video src='https://github.com/juanmanso/rn-walletconnect/assets/21087992/c87316de-ad48-42d2-b473-bbaca5b3bd21' width=400> |